### PR TITLE
Fix pagination iterator that reloaded first page

### DIFF
--- a/seshat_api/base_model.py
+++ b/seshat_api/base_model.py
@@ -96,7 +96,7 @@ class _Paginated:
             self._load_page(self.next_url, self.params)
 
         if not self.results:
-            self._load_page(self.endpoint, self.params)
+            # No more results to return; do not reload the first page
             raise StopIteration
 
         if self.model:

--- a/tests/test_seshat_api.py
+++ b/tests/test_seshat_api.py
@@ -1,6 +1,15 @@
+import pytest
 from pytest import raises
 import requests
-from seshat_api import SeshatAPI, get_variable_classes, get_variable_name, seshat_class_instance, get_frequencies
+from seshat_api import (
+    SeshatAPI,
+    get_variable_classes,
+    get_variable_name,
+    seshat_class_instance,
+    get_frequencies,
+)
+from seshat_api.base_model import _Paginated
+from seshat_api.constants import BASE_URL
 
 
 def test_get_variable_name():
@@ -29,6 +38,38 @@ def test_get_variable_classes():
     assert "ExternalConflictSides" in vc["crisisdb"]
     assert "OfficialReligions" in vc["rt"]
     assert "BigPonies" not in vc["wf"]
+
+
+def test_paginated_iteration_no_duplicates():
+    class DummyClient:
+        def __init__(self):
+            self.calls = []
+
+        def get(self, url, params):
+            self.calls.append(url)
+            if url == "/items":
+                return {
+                    "next": f"{BASE_URL}/items?page=2",
+                    "previous": None,
+                    "results": [{"id": 1}, {"id": 2}],
+                }
+            if url == "/items?page=2":
+                return {
+                    "next": None,
+                    "previous": f"{BASE_URL}/items",
+                    "results": [{"id": 3}],
+                }
+            raise AssertionError(f"Unexpected url {url}")
+
+    client = DummyClient()
+    pager = _Paginated(client, "/items")
+    ids = [item.id for item in pager]
+
+    assert ids == [1, 2, 3]
+    # Ensure only the two expected pages were fetched
+    assert client.calls == ["/items", "/items?page=2"]
+    # After iteration the pager should have no leftover results
+    assert pager.results == []
 
 
 # TODO: Use mocking instead of relying on the API


### PR DESCRIPTION
## Summary
- avoid refetching the first page when pagination iterator exhausts results
- add regression test ensuring paginated iteration doesn't duplicate items

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b078aafe0c8332ba1073dad68fd44f